### PR TITLE
Delete unnecessary `rust-toolchain.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,7 @@ repository = "https://github.com/Traverse-Research/android-sdkmanager-rs"
 keywords = ["android", "sdkmanager"]
 documentation = "https://docs.rs/android-sdkmanager-rs/"
 
-include = [
-    "Cargo.toml",
-    "LICENSE-*",
-    "src/**",
-]
+include = ["LICENSE-*", "/src"]
 
 [lib]
 name = "android_sdkmanager"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.58.1"
-components = ["rustfmt", "clippy"]
-targets = [ "aarch64-linux-android" ]


### PR DESCRIPTION
This is pointing to an ancient Rust version and shouldn't be needed to
build and use this repository.
