### PR TITLE
ci: Replace deprecated `actions-rs` with `run: cargo ...` and drop nightly build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,31 +8,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        rust: [stable, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
       - name: Cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --workspace --all-targets
+        run: cargo check --workspace --all-targets
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-      # Update mtime on all our files so that `clippy` rechecks them
-      - name: Touch source files for clippy recheck
-        run: find -path ./target -prune -o -name "*.rs" -exec touch {} +
-        shell: bash
+        run: cargo fmt --all -- --check
       - name: Cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
Making sure that this tool lints on `stable` is good enough, no need to opt in to unstable lints.
