### PR TITLE
respect proxy variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ name = "cargo-android-sdkmanager"
 path = "src/main.rs"
 
 [dependencies]
-ureq = "2.4"
+ureq = "2.8"
 roxmltree = "0.14"
 zip = "0.6"
 rayon = "1.5"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "1.58.1"
 components = ["rustfmt", "clippy"]
 targets = [ "aarch64-linux-android" ]


### PR DESCRIPTION
Just a small change to respect PROXY environment variables when downloading packages with ureq.
Just as a note, I started implementing this PR with ureq 2.4 manually checking environment variables, but realized that in later version ureq does this automatically with a simple agente configuration flag, so I updated ureq to latest version.
Also had to remove old rust channel "1.58.1" due to errors with other dependencies (already in project).